### PR TITLE
Allow file-like objects for WavAudio.read_file

### DIFF
--- a/dragonfly/engines/backend_kaldi/audio.py
+++ b/dragonfly/engines/backend_kaldi/audio.py
@@ -444,8 +444,11 @@ class WavAudio(object):
     @classmethod
     def read_file(cls, filename, realtime=False):
         """ Yields raw audio blocks from wav file, terminated by a None element. """
-        if not os.path.isfile(filename):
-            raise IOError("'%s' is not a file. Please use a different file path.")
+        try:
+            if not os.path.isfile(filename):
+                raise IOError("'%s' is not a file. Please use a different file path.")
+        except TypeError:
+            pass # Allow file-like objects
 
         with contextlib.closing(wave.open(filename, 'rb')) as file:
             # Validate the wave file's header


### PR DESCRIPTION
Allow in-memory byte streams to be used instead of just regular files.